### PR TITLE
pin to latest webview/make dxvk off by default (1/2 the bits this time) [broken pull]

### DIFF
--- a/32bitbyond.yaml
+++ b/32bitbyond.yaml
@@ -7,13 +7,18 @@ name: BYOND
 notes: "Requires Wine 10.5+ (may fail first time if Lutris had to install wine version).\
   \ Servers made for versions before 515 don't work well if at all. This does allow\
   \ TGUI to work with Wine, however older servers without TGUI may work better with\
-  \ the older installers.\r\nHere is a repo to track other common issues and guides\
-  \ for setting some things up\r\nhttps://github.com/kinggoldcatter/Wine-Byond-help"
+  \ the older installers \r\nBy Default; the script runs without DXVK (due to graphical issues)\
+  \ if your gpu doesn't support EGL; then you can enable DXVK with winetricks.\r\n \
+  \ \r\nHere is a repo to track other common issues and guides\
+  \ for setting some things up\r\nhttps://github.com/kinggoldcatter/Wine-Byond-help\
+  \ \r\nhow to get Webview2 Evergreen (x86)\r\nhttps://developer.microsoft.com/en-us/microsoft-edge/webview2/"
 runner: wine
 script:
   files:
-  - installer: http://www.byond.com/download/build/516/516.1667_byond.exe
-  - webview2: N/A:Evergreen Standalone Installer x86 downloaded from https://developer.microsoft.com/en-us/microsoft-edge/webview2
+  - installer: https://www.byond.com/download/build/516/516.1667_byond.exe
+  - webview2:
+        url: https://go.microsoft.com/fwlink/?linkid=2099617
+        filename: MicrosoftEdgeWebView2RuntimeInstallerX86.exe
   game:
     arch: win32
     exe: drive_c/Program Files/BYOND/bin/byond.exe
@@ -44,12 +49,6 @@ script:
       prefix: $GAMEDIR
   - task:
       arch: win32
-      app: dxvk
-      description: Installing dxvk with Winetricks
-      name: winetricks
-      prefix: $GAMEDIR
-  - task:
-      arch: win32
       description: setting msedgewebview2.exe to win7
       key: version
       name: set_regedit
@@ -59,7 +58,7 @@ script:
       value: win7
   - task:
       arch: win32
-      description: Installing Webview2
+      description: Installing Webview2 (if nothing appears, this failed!)
       exclude_processes: MicrosoftEdgeUpdate.exe
       executable: webview2
       name: wineexec

--- a/x64byondbeta.yaml
+++ b/x64byondbeta.yaml
@@ -16,7 +16,9 @@ runner: wine
 script:
   files:
   - installer: https://www.byond.com/download/build/516/516.1667_byond.exe
-  - webview2: ""
+  - webview2:
+        url: https://go.microsoft.com/fwlink/?linkid=2099617
+        filename: MicrosoftEdgeWebView2RuntimeInstallerX86.exe
   game:
     exe: drive_c/Program Files (x86)/BYOND/bin/byond.exe
     prefix: $GAMEDIR

--- a/x64byondbeta.yaml
+++ b/x64byondbeta.yaml
@@ -17,8 +17,8 @@ script:
   files:
   - installer: https://www.byond.com/download/build/516/516.1667_byond.exe
   - webview2:
-        url: https://go.microsoft.com/fwlink/?linkid=2099617
-        filename: MicrosoftEdgeWebView2RuntimeInstallerX86.exe
+        url: https://go.microsoft.com/fwlink/?linkid=2124701
+        filename: MicrosoftEdgeWebView2RuntimeInstallerX64.exe
   game:
     exe: drive_c/Program Files (x86)/BYOND/bin/byond.exe
     prefix: $GAMEDIR

--- a/x64byondbeta.yaml
+++ b/x64byondbeta.yaml
@@ -43,6 +43,15 @@ script:
       description: Installing fonts with Winetricks
       name: winetricks
       prefix: $GAMEDIR
+      
+  - task:
+      description: setting msedgewebview2.exe to win7 (Wine Work-Around)
+      key: version
+      name: set_regedit
+      path: HKEY_CURRENT_USER\Software\Wine\AppDefaults\msedgewebview2.exe
+      prefix: $GAMEDIR
+      type: REG_SZ
+      value: win7
 
   - task:
       args: /install

--- a/x64byondbeta.yaml
+++ b/x64byondbeta.yaml
@@ -7,13 +7,16 @@ name: BYOND
 notes: "Requires Wine 10.5+ (may fail first time if Lutris had to install wine version).\
   \ Servers made for versions before 515 don't work well if at all. This does allow\
   \ TGUI to work with Wine, however older servers without TGUI may work better with\
-  \ the older installers.\r\nHere is a repo to track other common issues and guides\
-  \ for setting some things up\r\nhttps://github.com/kinggoldcatter/Wine-Byond-help"
+  \ the older installers \r\nBy Default; the script runs without DXVK (due to graphical issues)\
+  \ if your gpu doesn't support EGL; then you can enable DXVK with winetricks.\r\n \
+  \ \r\nHere is a repo to track other common issues and guides\
+  \ for setting some things up\r\nhttps://github.com/kinggoldcatter/Wine-Byond-help\
+  \ \r\nhow to get Webview2 Evergreen (x86)\r\nhttps://developer.microsoft.com/en-us/microsoft-edge/webview2/"
 runner: wine
 script:
   files:
-  - installer: http://www.byond.com/download/build/516/516.1667_byond.exe
-  - webview2: https://github.com/aedancullen/webview2-evergreen-standalone-installer-archive/releases/download/109.0.1518.78/MicrosoftEdgeWebView2RuntimeInstallerX64.exe
+  - installer: https://www.byond.com/download/build/516/516.1667_byond.exe
+  - webview2: ""
   game:
     exe: drive_c/Program Files (x86)/BYOND/bin/byond.exe
     prefix: $GAMEDIR
@@ -38,30 +41,20 @@ script:
       description: Installing fonts with Winetricks
       name: winetricks
       prefix: $GAMEDIR
+
   - task:
-      app: dxvk
-      description: Installing dxvk with Winetricks
-      name: winetricks
-      prefix: $GAMEDIR
-  - task:
-      description: setting msedgewebview2.exe to win7
-      key: version
-      name: set_regedit
-      path: HKEY_CURRENT_USER\Software\Wine\AppDefaults\msedgewebview2.exe
-      prefix: $GAMEDIR
-      type: REG_SZ
-      value: win7
-  - task:
-      args: /silent /install
-      description: Installing Webview2 (may take a moment)
+      args: /install
+      description: Installing Webview2 (if nothing appears, you have to install this yourself)
       exclude_processes: MicrosoftEdgeUpdate.exe
       executable: webview2
       name: wineexec
       prefix: $GAMEDIR
+
   - task:
       description: Terminating MicrosoftEdgeUpdate.exe...
       name: winekill
       prefix: $GAMEDIR
+
   - task:
       args: /S
       description: Installing BYOND
@@ -75,6 +68,7 @@ script:
       executable: $GAMEDIR/drive_c/Program Files (x86)/BYOND/directx/DXSETUP.exe
       name: wineexec
       prefix: $GAMEDIR
+
 slug: byond-v5161667
 steamid: null
 version: v516.1667


### PR DESCRIPTION
same as before. (but 32-bit prefixes)

Tested in wine 10.8

child of #12 