### PR TITLE
redo sanity checking but with grep

### DIFF
--- a/x64byond.yaml
+++ b/x64byond.yaml
@@ -63,6 +63,11 @@ script:
       description: Terminating MicrosoftEdgeUpdate.exe...
       name: winekill
       prefix: $GAMEDIR
+      
+  - execute:
+      description: Sanity checking webview2..
+      command: find "$GAMEDIR/drive_c/" -iname msedgewebview2.exe | grep .
+      
   - task:
       args: /S
       description: Installing BYOND
@@ -70,6 +75,11 @@ script:
       name: wineexec
       prefix: $GAMEDIR
       return_code: 50944
+      
+  - execute:
+      description: Sanity Checking BYOND...
+      command: find "$GAMEDIR/drive_c/" -path "*BYOND/bin/byond.exe" | grep .
+
   - task:
       args: /silent
       description: Installing BYOND packaged DirectX


### PR DESCRIPTION
Added sanity checks for webview2 and BYOND installation.

should close out early with error code 256 if the files being grep'd are not found. (explicitly tested on my distribution with lutris 5.22 non-flatpak)

child of #19 